### PR TITLE
Small fixes to XDS <> FHIR metadata mappers

### DIFF
--- a/src/main/java/org/openehealth/app/xdstofhir/registry/common/mapper/AbstractXdsToFhirMapper.java
+++ b/src/main/java/org/openehealth/app/xdstofhir/registry/common/mapper/AbstractXdsToFhirMapper.java
@@ -22,13 +22,7 @@ import org.hl7.fhir.r4.model.PractitionerRole;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.StringType;
 import org.openehealth.app.xdstofhir.registry.common.MappingSupport;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Author;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Name;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Telecom;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Timestamp;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.XDSMetaClass;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.*;
 
 public abstract class AbstractXdsToFhirMapper {
 
@@ -51,7 +45,7 @@ public abstract class AbstractXdsToFhirMapper {
 
     protected Identifier fromIdentifier(final Identifiable id) {
         var identifier = new Identifier();
-        identifier.setSystem(OID_URN + id.getAssigningAuthority().getUniversalId());
+        identifier.setSystem(nullSafeConvertToUrn(id.getAssigningAuthority()));
         identifier.setValue(id.getId());
         return identifier;
     }
@@ -77,7 +71,7 @@ public abstract class AbstractXdsToFhirMapper {
     protected Reference fromAuthor(final Author author) {
         var role = new PractitionerRole();
         var doc = new Practitioner();
-        if((author.getAuthorPerson() != null) && !author.getAuthorPerson().isEmpty()) {
+        if (author.getAuthorPerson() != null && !author.getAuthorPerson().isEmpty()) {
             if (!author.getAuthorPerson().getName().isEmpty())
                 doc.setName(singletonList(fromName(author.getAuthorPerson().getName())));
             if (!author.getAuthorPerson().getId().isEmpty())
@@ -95,7 +89,7 @@ public abstract class AbstractXdsToFhirMapper {
             org.setName(xdsAuthorOrg.getOrganizationName());
             if (xdsAuthorOrg.getIdNumber() != null) {
                 var identifier = new Identifier();
-                identifier.setSystem(OID_URN + xdsAuthorOrg.getAssigningAuthority().getUniversalId());
+                identifier.setSystem(nullSafeConvertToUrn(xdsAuthorOrg.getAssigningAuthority()));
                 identifier.setValue(xdsAuthorOrg.getIdNumber());
                 org.addIdentifier(identifier);
             }
@@ -103,6 +97,10 @@ public abstract class AbstractXdsToFhirMapper {
         }
         reference.setResource(role);
         return reference;
+    }
+
+    private static String nullSafeConvertToUrn(AssigningAuthority xdsAuthorOrg) {
+        return xdsAuthorOrg == null ? null : OID_URN + xdsAuthorOrg.getUniversalId();
     }
 
     protected CodeableConcept convertToCode(final Identifiable id) {
@@ -117,7 +115,7 @@ public abstract class AbstractXdsToFhirMapper {
         return fhirConcept;
     }
 
-    protected ContactPoint fromTelecom (final Telecom xdsTelecom) {
+    protected ContactPoint fromTelecom(final Telecom xdsTelecom) {
         var cp = new ContactPoint();
         if (xdsTelecom.getEmail() != null) {
             cp.setSystem(ContactPointSystem.EMAIL);

--- a/src/main/java/org/openehealth/app/xdstofhir/registry/register/RegisterDocumentsProcessor.java
+++ b/src/main/java/org/openehealth/app/xdstofhir/registry/register/RegisterDocumentsProcessor.java
@@ -394,9 +394,9 @@ public class RegisterDocumentsProcessor implements Iti42Service {
      */
     private void assignRegistryValues(List<Association> associations) {
         for (var assoc : associations) {
-            if (!assoc.getEntryUuid().startsWith(MappingSupport.UUID_URN)) {
-                var previousIdentifier = assoc.getEntryUuid();
+            if (assoc.getEntryUuid() == null || !assoc.getEntryUuid().startsWith(MappingSupport.UUID_URN)) {
                 assoc.assignEntryUuid();
+                var previousIdentifier = assoc.getEntryUuid();
                 associations.stream().forEach(as -> {
                     as.setSourceUuid(as.getSourceUuid().replace(previousIdentifier, assoc.getEntryUuid()));
                     as.setTargetUuid(as.getTargetUuid().replace(previousIdentifier, assoc.getEntryUuid()));


### PR DESCRIPTION
Resolve mapping issues in #14 
 - XON <> Organization. XON can have an identifier without assigning authority if it is an OID.
 - XCN <> Practitioner. The code expects an assigning authority for the identifier. But either the name or the identifier is expected. So in case of a name-only XCN, the identifier does not need to be mapped. The rules for XCN are:
 - Assoc entryUuid might be empty on submission and then needs to be assigned by registry